### PR TITLE
Change url for theme submodule to use https instead of ssh

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,4 +6,4 @@
 	url = https://github.com/efavdb/efavdb.github.io.git
 [submodule "elegant-theme"]
 	path = elegant-theme
-	url = git@github.com:efavdb/elegant.git
+        url = https://github.com/EFavDB/elegant.git


### PR DESCRIPTION
jonathan's `git submodule update --init --recursive` didn't seem to work for the theme submodule.  The only difference I can see is that its url in `.gitmodules` uses ssh instead of https.  (not sure if Jonathan has ssh token set up with github?)