### PR TITLE
Cathy/publish full paths

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -3,7 +3,7 @@ name: Build Webiste
 on:
   pull_request:
     types: [closed]
-    
+
 jobs:
   build:
 
@@ -29,7 +29,7 @@ jobs:
         git submodule update --init --recursive
     - name: Publish Site
       run: |
-        make html
+        make publish
         REMOTE=https://damien:${{ secrets.write }}@github.com/EFavDB/efavdb.github.io
         git clone ${REMOTE} website
         yes | cp -rf output/* website

--- a/README.md
+++ b/README.md
@@ -14,7 +14,12 @@ ls output
 
 git submodule update --init --recursive
 # now those same dirs should no longer be empty
+```
 
+
+Below is optional now that publishing to github happens automatically with PR merge.  
+Feel free to skip.
+```shell
 cd output
 git remote -v
 # should show
@@ -47,7 +52,11 @@ make devserver
 
 ## Developing
 
-- The markdown articles are located under `content/`.
+- The markdown articles are located under `content/`.  Feel free to
+  place WIP drafts in `content/articles/drafts` for easy tracking, but
+  technically, you can put them anywhere and they won't be published
+  unless you specify their status as such (default is `draft`) in the
+  article metadata.
 - New images should be placed under `content/images/` as opposed to
   `content/wp-content/...`.  The latter made sense to keep as part of
   the migration from WordPress, but we don't need to keep adding to it
@@ -61,6 +70,18 @@ From the root of the project:
 - Open up the dev website at http://localhost:8000/
 - Make your changes to the `content/` dir, where the articles are
   located. Verify your changes are picked up on the dev website.
+- Note, Disqus comments won't be visible in dev mode because Disqus
+  requires absolute URLs.
+- If you want to check the published version of the site (uses
+  absolute URLs, which you can see in page source links), run:
+  - `make publish`
+  - `make serve` -- see site at localhost:8000.
+- Open a PR with your content changes.  When you merge the PR, changes
+  will automatically be published to github pages.  (Thanks Damien!)
+
+
+
+### DEPRECATED steps for manual publishing to github pages
 
 The files in the `output/` subdir should have been automatically
 regenerated in development mode.

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -42,10 +42,15 @@ PAGE_PATHS = ['pages']
 STATIC_PATHS = ['images', 'wp-content']
 PAGE_EXCLUDES = ['wp-content']
 ARTICLE_EXCLUDES = ['wp-content', 'articles/drafts']
+
+# clean-url (lacks .html) -- n.b. disqus mapping assumes slug is
+# missing .html, would have to redo it if we revert this
+ARTICLE_URL = "{slug}"
+
 # have output paths mirror source content's filesystem path hierarchy
 # n.b. does not play well with wp-content static path references
 #PATH_METADATA = '(?P<path_no_ext>.*)\..*'
-#ARTICLE_URL = ARTICLE_SAVE_AS = PAGE_URL = PAGE_SAVE_AS = '{path_no_ext}.html'
+
 
 # Blogroll
 LINKS = (('Home', '/index.html'),
@@ -59,7 +64,6 @@ LINKS = (('Home', '/index.html'),
 SOCIAL = (('Twitter', 'https://twitter.com/efavdb'),
           ('Github', 'https://github.com/efavdb'),
           ('Youtube', 'https://www.youtube.com/channel/UClfvjoSiu0VvWOh5OpnuusA'),)
-
 
 
 # Uncomment following line if you want document-relative URLs when developing
@@ -86,7 +90,7 @@ PROJECTS = [{'name': 'linselect', 'url': '/pages/linselect.html',
 
 
 DISPLAY_CATEGORIES_ON_MENU = False
-DISPLAY_PAGES_ON_MENU = True  # turn this off so we can specify ordering
+DISPLAY_PAGES_ON_MENU = True
 CACHE_CONTENT = False
 CACHE_PATH = '.cache'
 LOAD_CONTENT_CACHE = False

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -10,9 +10,8 @@ CURRENT_DIR_PATH = Path(__file__).resolve().parent
 AUTHOR = 'efavdb'
 SITENAME = 'EFAVDB'
 SITESUBTITLE = "Everybody's Favorite Data Blog"
-SITEURL = 'http://efavdb.github.io'
+SITEURL = ''
 GITHUB_URL = 'https://github.com/efavdb'
-#SITEURL = 'localhost'
 THEME = f'{CURRENT_DIR_PATH}/elegant-theme'
 PATH = 'content'
 
@@ -74,7 +73,6 @@ PLUGINS = ['sitemap',
            'neighbors',
            'tipue_search',
            'share_post',
-           'disqus_static',
 ]
 DIRECT_TEMPLATES = ['index', 'tags', 'categories', 'authors', 'archives', 'search']
 
@@ -145,10 +143,6 @@ SITEMAP = {
         'indexes': 'daily'
     },
 }
-
-# disqus
-DISQUS_SITENAME = 'EFAVDB'
-DISQUS_DISPLAY_COUNTS = True
 
 # publish
 DELETE_OUTPUT_DIRECTORY = False

--- a/publishconf.py
+++ b/publishconf.py
@@ -11,16 +11,16 @@ sys.path.append(os.curdir)
 from pelicanconf import *
 
 # If your site is available via HTTPS, make sure SITEURL begins with https://
-SITEURL = 'http'
+SITEURL = 'https://efavdb.github.io'
 RELATIVE_URLS = False
 
 FEED_ALL_ATOM = 'feeds/all.atom.xml'
 CATEGORY_FEED_ATOM = 'feeds/{slug}.atom.xml'
 
-DELETE_OUTPUT_DIRECTORY = True
+DELETE_OUTPUT_DIRECTORY = False
 
 
 # Following items are often useful when publishing
 
-#DISQUS_SITENAME = ""
+DISQUS_SITENAME = 'efavdb2'
 #GOOGLE_ANALYTICS = ""


### PR DESCRIPTION
Fix disqus comments
- needed absolute urls (fix settings in publish conf)
- supplied correct shortname from disqus in publishconf.py and a few other publish-specific settings.  updated build docs to use `make publish` instead of `make html`.
- outside of this PR, did a url migration in disqus from wordpress to efavdb.github.io.  Will have to to a domain migration / url mapping migration again whenever we update the domain name, but it was good to check that this works.
- updated readme
- removed disqus_static plugin, which was not necessary for embedding live disqus in our articles